### PR TITLE
Update with TTRPGs from various top sales lists

### DIFF
--- a/src/algos/ttrpg.ts
+++ b/src/algos/ttrpg.ts
@@ -64,6 +64,7 @@ const terms = [
   
   // paizo
   'pathfinder',
+  'starfinder',
   
   // Free League
   'mork borg',
@@ -77,9 +78,29 @@ const terms = [
   'vaesen',
   'r\.? talsorian',
   'darrington press',
+
+  // Orr Report 2021 Top 25
+  // https://blog.roll20.net/media/orrreport-2021-q4-long.pdf
+  // this section only contains games from the Orr Report that weren't 
+  // in other sections already
+  'tormenta',
+  'das schwarze auge',
+  'apocalypse world',
+  'mutants and masterminds',
+  'shadowrun',
+  'savage worlds',
+  'vampire: the masquerade',
+  'lancer',
+  'dungeon world',
+
+  // ICV2 Report Fall 2022
+  // https://icv2.com/articles/markets/view/53650/top-hobby-channel-roleplaying-games-fall-2022
+  'transformers rpg',
   
   // other games
   'warhammer',
+  'wrath and glory',
+  'wrath & glory',
   'mutant:? year zero',
   'alien rpg',
   'fate system',


### PR DESCRIPTION
I looked over https://icv2.com/articles/markets/view/53650/top-hobby-channel-roleplaying-games-fall-2022 and https://blog.roll20.net/posts/the-orr-report-q4-2021/ and extracted games which weren't already on the list (not many). I put 'starfinder' in the Paizo section and various Warhammer games next to 'warhammer' in the other games section.

I also left a few out -- inSANe is too general a term to successfully use in a feed.